### PR TITLE
release: v2.7.0 路由DFS重构与中间件顺序修复

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ homepage = "https://github.com/silent-rs/silent"
 license = "Apache-2.0"
 readme = "./readme.md"
 repository = "https://github.com/silent-rs/silent"
-version = "2.6.0"
+version = "2.7.0"
 
 [workspace.dependencies]
 async-trait = "0.1.88"


### PR DESCRIPTION
本次发布 v2.7.0 主要变更：

- 路由：重构为 DFS RouteTree，支持 `**` 全路径通配，子优先、父级回退
- 中间件：按层级（根→叶）收集中间件并修正执行顺序；按需构建 Next 链
- 性能：匹配阶段以切片/strip_prefix 降低分配；整体性能提升（详见 benchmark/results/route_tree_dfs.md）
- 兼容：修复 Rust 1.89 的生命周期与 clippy 警告（collapsible_if 等）
- 版本：工作区版本号提升至 2.7.0

验证：
- cargo clippy --all-targets --all-features --tests --benches -- -D warnings 通过
- benchmark 套件运行通过；examples 验证中间件顺序正确

请审阅合并以发布新版本。