### PR TITLE
fix(core): 修复 FullPath(**) 与 DFS 终止逻辑导致 405

### DIFF
--- a/silent/src/handler/handler_trait.rs
+++ b/silent/src/handler/handler_trait.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use crate::core::res_body::ResBody;
 use crate::{Request, Response, Result, SilentError};
 use async_trait::async_trait;
 use http::{Method, StatusCode};
@@ -17,17 +18,29 @@ pub trait Handler: Send + Sync + 'static {
 #[async_trait]
 impl Handler for HashMap<Method, Arc<dyn Handler>> {
     async fn call(&self, req: Request) -> Result<Response> {
-        match self.clone().get(req.method()) {
-            None => Err(SilentError::business_error(
-                StatusCode::METHOD_NOT_ALLOWED,
-                "method not allowed".to_string(),
-            )),
-            Some(handler) => {
-                let mut pre_res = Response::empty();
-                pre_res.configs = req.configs();
-                pre_res.copy_from_response(handler.call(req).await?);
-                Ok(pre_res)
-            }
+        let method = req.method().clone();
+        // 直接命中匹配的方法
+        if let Some(handler) = self.clone().get(&method) {
+            let mut pre_res = Response::empty();
+            pre_res.configs = req.configs();
+            pre_res.copy_from_response(handler.call(req).await?);
+            return Ok(pre_res);
         }
+
+        // 特殊处理：HEAD 无显式处理器时回退到 GET，并清空响应体
+        if method == http::Method::HEAD
+            && let Some(get_handler) = self.clone().get(&http::Method::GET)
+        {
+            let mut pre_res = Response::empty();
+            pre_res.configs = req.configs();
+            pre_res.copy_from_response(get_handler.call(req).await?);
+            pre_res.set_body(ResBody::None);
+            return Ok(pre_res);
+        }
+
+        Err(SilentError::business_error(
+            StatusCode::METHOD_NOT_ALLOWED,
+            "method not allowed".to_string(),
+        ))
     }
 }


### PR DESCRIPTION
变更说明
- 修复 FullPath(**) 匹配未吞尽路径导致 405
- 调整 DFS：URL 终止时仍尝试所有子节点，避免 <path:**> 漏匹配
- HEAD 无处理器时回退 GET 并清空响应体，避免静态资源 405

根因
- <path:**> 仅消费单段，余下路径导致选中无处理器结点触发 405
- last_path 为空时只尝试空路径子节点，<path:**> 无法匹配

具体变更
- silent/src/route/route_tree.rs
  - SpecialPath::FullPath：记录完整剩余路径但允许继续匹配子节点；子节点不匹配回退父节点处理器
  - dfs_match：last_path 为空时尝试所有子节点；若无匹配，仅在当前结点有处理器时成功，否则回溯
- silent/src/handler/handler_trait.rs
  - HashMap Handler：HEAD 无映射时回退 GET，并清空响应体

验证
- file_server 示例：GET/HEAD 均 200
- 单测：cargo test -p silent --lib 与 --doc 通过
- 全量：cargo test --all 通过（本地）

风险与兼容性
- 行为更贴近预期：<path:**> 子节点优先、父节点回退；HEAD 语义更合理
- 不涉及 API 破坏性变更

关联问题
- 405 与 FullPath(**) 匹配相关问题
