### PR TITLE
fix(route): 修复字符串路径段空匹配导致 /oauth2/applications 返回405

### DIFF
--- a/docs/requirements/routing-oauth2-405.md
+++ b/docs/requirements/routing-oauth2-405.md
@@ -1,0 +1,41 @@
+# 路由需求-修复 /oauth2/applications 返回405
+
+- 背景：在如下路由结构下，请求 GET /oauth2/applications 出现 405 Method Not Allowed。
+
+```
+Route::new("oauth2")
+    .append(
+        Route::new("applications")
+            .get(get_applications)
+            .post(create_application)
+            .append(
+                Route::new("<id:str>")
+                    .get(get_application)
+                    .put(update_application)
+                    .delete(delete_application)
+                    .append(Route::new("status").patch(update_status))
+                    .append(Route::new("regenerate-secret").post(regenerate_secret))
+                    .append(Route::new("access-config").put(update_access_config)),
+            ),
+    )
+```
+
+- 期望：GET /oauth2/applications 命中 applications 节点的 GET 处理器，返回 200。
+- 现象：匹配误入子节点 <id:str>，导致处理器选择异常并最终返回 405。
+
+## 根因
+
+- 路由特殊段 <id:str> 在匹配实现中将空路径段视为可匹配（将空字符串注入路径参数），
+  当请求正好落在父节点（applications）时，DFS 会继续尝试子节点 <id:str> 并误判匹配成功，
+  从而覆盖了父节点的处理器选择。
+
+## 需求与修复要点
+
+- <key:str> 类型的特殊段匹配必须要求当前路径段非空；空段不应匹配。
+- 其他数值类型（<id:int>、<id:i64> 等）因解析失败已自然不匹配，此变更与其语义一致。
+- 修复后应增加单元测试，覆盖 GET /oauth2/applications 场景，确保不再返回 405。
+
+## 验收
+
+- 运行 cargo test -p silent --tests 全部通过。
+- GET /oauth2/applications 命中父节点 applications 的 GET 处理器。


### PR DESCRIPTION
背景: 在路由 oauth2/applications 下, GET /oauth2/applications 返回 405。

修复: 调整 SpecialPath::String 匹配逻辑, 当 local_path 为空时不再匹配, 避免 DFS 误入 <id:str> 子节点覆盖父节点处理器。

测试: 新增单元测试 oauth2_applications_get_should_not_405, 覆盖 GET /oauth2/applications 正常返回场景。cargo test 全部通过。

文档: 新增 docs/requirements/routing-oauth2-405.md, 记录问题背景、根因、修复要点与验收。