### PR TITLE
fix(core): 修复路由树未注入全局配置导致示例500

### DIFF
--- a/silent/src/route/route_tree.rs
+++ b/silent/src/route/route_tree.rs
@@ -134,6 +134,9 @@ impl RouteTree {
 impl Handler for RouteTree {
     async fn call(&self, req: Request) -> crate::error::SilentResult<Response> {
         let (mut req, last_path) = req.split_url();
+        if let Some(configs) = self.get_configs().cloned() {
+            *req.configs_mut() = configs;
+        }
         // 入口处匹配当前结点一次
         let (matched, remain) = self.match_current(&mut req, last_path.as_str());
         if !matched {


### PR DESCRIPTION
在 RouteTree::call 开始处将当前节点的 Configs 克隆并写入 req.configs_mut()，确保通过 Request::get_config 能获取到在 Server/Route 上设置的配置。\n\n修复 examples/configs 示例中 get_config 返回 ConfigNotFound 进而触发 500 的问题。\n\n该变更不覆盖既有 None 情况，仅在节点存在配置时注入，兼容现有逻辑。
